### PR TITLE
Add integration tests and CI workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,21 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test -- -i

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,8 +44,9 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",
-    "prettier": "^3.5.3",
     "jest": "^29.0.0",
+    "mongodb-memory-server": "^8.12.1",
+    "prettier": "^3.5.3",
     "supertest": "^6.3.3"
   }
 }

--- a/backend/tests/api.integration.test.js
+++ b/backend/tests/api.integration.test.js
@@ -1,0 +1,120 @@
+const mongoose = require('mongoose');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+jest.mock('../config/email', () => ({
+  sendEmail: (_body, res, message) => res.status(200).send({ message }),
+}));
+
+let app;
+let mongod;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  const uri = mongod.getUri();
+  process.env.MONGO_URI = uri;
+  process.env.TOKEN_SECRET = 'testsecret';
+  process.env.JWT_SECRET_FOR_VERIFY = 'verifysecret';
+  process.env.EMAIL_USER = 'test@example.com';
+  process.env.EMAIL_PASS = 'pass';
+  process.env.SERVICE = 'test';
+  process.env.HOST = 'localhost';
+  process.env.EMAIL_PORT = '465';
+  app = require('../index');
+});
+
+afterAll(async () => {
+  await mongoose.connection.dropDatabase();
+  await mongoose.connection.close();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  const collections = Object.keys(mongoose.connection.collections);
+  for (const collection of collections) {
+    await mongoose.connection.collections[collection].deleteMany({});
+  }
+});
+
+describe('Authentication flow', () => {
+  it('should sign up and login a user', async () => {
+    const signupRes = await request(app)
+      .post('/api/user/signup')
+      .send({ name: 'Test', email: 'test@example.com', password: '123456' });
+    expect(signupRes.statusCode).toBe(200);
+
+    const User = require('../model/User');
+    const user = await User.findOne({ email: 'test@example.com' });
+    user.status = 'active';
+    await user.save();
+
+    const loginRes = await request(app)
+      .post('/api/user/login')
+      .send({ email: 'test@example.com', password: '123456' });
+    expect(loginRes.statusCode).toBe(200);
+    expect(loginRes.body.data.token).toBeDefined();
+  });
+});
+
+describe('Product creation', () => {
+  it('should create a product', async () => {
+    const Brand = require('../model/Brand');
+    const Category = require('../model/Category');
+    const brand = await Brand.create({ name: 'Acme', email: 'b@example.com' });
+    const category = await Category.create({ parent: 'Cat', productType: 'type' });
+
+    const productData = {
+      img: 'http://example.com/img.png',
+      title: 'Prod',
+      unit: 'pc',
+      imageURLs: [],
+      parent: 'Cat',
+      price: 100,
+      quantity: 10,
+      brand: { name: brand.name, id: brand._id },
+      category: { name: category.parent, id: category._id },
+      status: 'in-stock',
+      productType: 'type',
+      description: 'desc',
+    };
+
+    const res = await request(app).post('/api/product/add').send(productData);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.title).toBe('Prod');
+  });
+});
+
+describe('Order workflow', () => {
+  it('should create an order', async () => {
+    const User = require('../model/User');
+    const user = await User.create({
+      name: 'OrderUser',
+      email: 'order@example.com',
+      password: '123456',
+      status: 'active',
+    });
+
+    const orderData = {
+      user: user._id,
+      cart: [],
+      name: 'OrderUser',
+      address: 'addr',
+      email: 'order@example.com',
+      contact: '123',
+      city: 'City',
+      country: 'Country',
+      zipCode: '111',
+      subTotal: 100,
+      shippingCost: 0,
+      discount: 0,
+      totalAmount: 100,
+      paymentMethod: 'cod',
+      status: 'pending',
+    };
+
+    const res = await request(app).post('/api/order/saveOrder').send(orderData);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.order).toBeDefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration tests for authentication, product creation, and orders
- include mongodb-memory-server for isolated DB
- configure GitHub Actions to run the backend tests

## Testing
- `npm test -- -i` *(fails: jest not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685eaeb20a68832aa9e3c29ca21472ec